### PR TITLE
fix: add the lost field is_built back to ideas

### DIFF
--- a/src/db/schemas/schema.ts
+++ b/src/db/schemas/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, varchar, serial, date, timestamp, foreignKey, text, integer } from "drizzle-orm/pg-core"
+import { pgTable, varchar, serial, date, timestamp, foreignKey, text, integer, boolean } from "drizzle-orm/pg-core"
 import { sql } from "drizzle-orm"
 
 
@@ -20,6 +20,7 @@ export const ideas = pgTable("ideas", {
 	idea: text().notNull(),
 	description: text().notNull(),
 	technologies: text().notNull(),
+	isBuilt: boolean("is_built").default(false),
 	likes: integer().default(0),
 	createdAt: timestamp("created_at", { mode: 'string' }).default(sql`CURRENT_TIMESTAMP`),
 	updatedAt: timestamp("updated_at", { mode: 'string' }),


### PR DESCRIPTION
**Why**: The field `is_built` was somehow lost in `db.sql` thus didn't make it into the ORM schema. This should fix the *Failed to load your ideas* issue in [votte.flushingtech.org](votte.flushingtech.org) .