### PR TITLE
SQL based migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Rename `.env.template` to `.env`. The `DATABASE_URL` is configured to connect to
 It's also used to apply changes to the database, also known as "migrations".
 
 - Update `src/db/schemas/` to make changes to the db, then,
-- `npm run db` to apply changes to the database.
-- `npm run db-studio` to launch a UI for managing the database.
+- `npm run db:generate` to generate SQL needed for the migrations. If custom SQL is needed for a migration, use `npm run db:generate:custom` and add the SQL to the generate file.
+- `npm run db:migrate` to apply changes to the database
+
+Run `npm run db:studio` to launch a UI for managing the database.
 
 ### Frontend
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
-  out: './drizzle',
+  out: './src/db/migrations',
   schema: './src/db/schemas/**/*.ts',
   dialect: 'postgresql',
   dbCredentials: {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon index.js",
-    "db": "drizzle-kit push",
-    "db-studio": "drizzle-kit studio"
+    "db:ci": "npm run db:generate && npm run db:dirty-migrations && npm run db:migrate",
+    "db:dirty-migrations": "test -z \"$(git status --porcelain -- ./src/db/migrations)\" || echo 'Dirty migrations found! Run `npm run db:generate` and ensure migrations are committed.'",
+    "db:migrate": "drizzle-kit migrate",
+    "db:generate": "drizzle-kit generate",
+    "db:generate:custom": "drizzle-kit generate --custom",
+    "db:studio": "drizzle-kit studio"
   },
   "keywords": [],
   "author": "",

--- a/src/db/migrations/0000_violet_corsair.sql
+++ b/src/db/migrations/0000_violet_corsair.sql
@@ -1,0 +1,93 @@
+CREATE TABLE IF NOT EXISTS "admin" (
+	"email" varchar(255) PRIMARY KEY NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"event_date" date NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"stage" integer DEFAULT 1,
+	"eventTime" time,
+	"link" text,
+	"current_sub_stage" text DEFAULT '1'
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ideas" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"idea" text NOT NULL,
+	"description" text NOT NULL,
+	"technologies" text NOT NULL,
+	"likes" integer DEFAULT 0,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"event_id" integer,
+	"is_built" boolean DEFAULT false,
+	"stage" integer DEFAULT 1,
+	"average_score" double precision DEFAULT 0
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "likes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_email" varchar(255) NOT NULL,
+	"idea_id" integer NOT NULL,
+	"liked_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "unique_user_like" UNIQUE("user_email","idea_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "results" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"event_id" integer NOT NULL,
+	"category" varchar(50) NOT NULL,
+	"winning_idea_id" integer NOT NULL,
+	"votes" integer DEFAULT 0,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "unique_event_category" UNIQUE("event_id","category")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "votes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_email" varchar(255) NOT NULL,
+	"idea_id" integer NOT NULL,
+	"event_id" integer NOT NULL,
+	"vote_type" varchar(50),
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "ideas" ADD CONSTRAINT "ideas_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "likes" ADD CONSTRAINT "likes_idea_id_fkey" FOREIGN KEY ("idea_id") REFERENCES "public"."ideas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "results" ADD CONSTRAINT "results_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "results" ADD CONSTRAINT "results_winning_idea_id_fkey" FOREIGN KEY ("winning_idea_id") REFERENCES "public"."ideas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "votes" ADD CONSTRAINT "votes_idea_id_fkey" FOREIGN KEY ("idea_id") REFERENCES "public"."ideas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "votes" ADD CONSTRAINT "votes_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/src/db/migrations/meta/0000_snapshot.json
+++ b/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,439 @@
+{
+  "id": "6dd80e97-6f49-4e3e-b110-57925ef637e5",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin": {
+      "name": "admin",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "eventTime": {
+          "name": "eventTime",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_sub_stage": {
+          "name": "current_sub_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ideas": {
+      "name": "ideas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idea": {
+          "name": "idea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "technologies": {
+          "name": "technologies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_built": {
+          "name": "is_built",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ideas_event_id_fkey": {
+          "name": "ideas_event_id_fkey",
+          "tableFrom": "ideas",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idea_id": {
+          "name": "idea_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked_at": {
+          "name": "liked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "likes_idea_id_fkey": {
+          "name": "likes_idea_id_fkey",
+          "tableFrom": "likes",
+          "tableTo": "ideas",
+          "columnsFrom": [
+            "idea_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_like": {
+          "name": "unique_user_like",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_email",
+            "idea_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.results": {
+      "name": "results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winning_idea_id": {
+          "name": "winning_idea_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes": {
+          "name": "votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "results_event_id_fkey": {
+          "name": "results_event_id_fkey",
+          "tableFrom": "results",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "results_winning_idea_id_fkey": {
+          "name": "results_winning_idea_id_fkey",
+          "tableFrom": "results",
+          "tableTo": "ideas",
+          "columnsFrom": [
+            "winning_idea_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_category": {
+          "name": "unique_event_category",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idea_id": {
+          "name": "idea_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_idea_id_fkey": {
+          "name": "votes_idea_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "ideas",
+          "columnsFrom": [
+            "idea_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_event_id_fkey": {
+          "name": "votes_event_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1739939787847,
+      "tag": "0000_violet_corsair",
+      "breakpoints": true
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "buildCommand": "mkdir -p /vercel/path0/public && touch /vercel/path0/public/placeholder && npm run db",
+  "buildCommand": "mkdir -p /vercel/path0/public && touch /vercel/path0/public/placeholder && npm run db:ci",
   "functions": {
     "api/index.js": {
       "memory": 1024,


### PR DESCRIPTION
This PR changes the Drizzle DB migrations from simple "push" to "generate and apply SQL".

A simple "push" calculated the changes needed to modify the DB, and applied them directly. However, this could/did lead to broken migrations due to unresolved conflicts.

Instead, a "generate and apply SQL" would avoid broken migrations by breaking hard and fast, since conflict-free SQL would need to be generated before applying a migration. Additionally, SQL migrations will enable DB seeding, enabling us to add data during migrations, eg. add or delete rows from tables.

This will enable a stronger codebase-first git-ops approach to DB migrations by requiring all migrations to be validated and reviewed during the PR stage.

Please review the README for the new `npm run` commands.

A baseline of the current DB state has been generated in `src/db/migrations` by running `npm run db:generate`

A new `npm run db:ci` command is run by Vercel, which checks if migrations were not generated before being applied.